### PR TITLE
Ignore decimal separator when parsing version fetched from GitHub

### DIFF
--- a/src/MainWindow.xaml.cs
+++ b/src/MainWindow.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using prism.Fonts;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net.Http;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -115,7 +116,7 @@ namespace prism
                 try
                 {
                     string RemoteContent = await client.GetStringAsync(Config.VersionServer);
-                    double ServerVersion = double.Parse(RemoteContent);
+                    double ServerVersion = double.Parse(RemoteContent, CultureInfo.InvariantCulture);
 
                     if (ServerVersion > Config.Version)
                     {


### PR DESCRIPTION
Fixes this on some systems:
![System.FormatException](https://github.com/lemonekq/prism/assets/81181783/8ffae1d7-63e3-4bea-9cc4-5bd767abaaca)